### PR TITLE
Implement optional inputs, dark mode and history control

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 PartnerReply is a small React + TypeScript application that assists WiziShop support agents in crafting replies. It analyzes a partner's message with OpenAI, classifies the request and produces a concise answer, including any code snippets to copy.
 
+Features:
+
+- Optional fields to provide HTML, CSS/JS code or an image screenshot.
+- Animated loader while OpenAI generates the answer.
+- Dark and light mode toggle.
+- Recent history of generated replies with ability to clear it.
+
 ## Setup
 
 1. Install dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import MessageInput from "./components/MessageInput";
 import TagNature from "./components/TagNature";
 import ApiKeyInput from "./components/ApiKeyInput";
 import CopyButton from "./components/CopyButton";
 import CodeBlockCard from "./components/CodeBlockCard";
 import HistoryPanel from "./components/HistoryPanel";
+import OptionsBar from "./components/OptionsBar";
 import { analyzeNature } from "./utils/analyzeNature";
 import { extractCodeBlocks } from "./utils/extractCodeBlocks";
 import { getOpenAI } from "./utils/openaiClient";
@@ -16,6 +17,9 @@ import { v4 as uuidv4 } from "uuid";
 export default function App() {
   const [apiKey, setApiKey] = useState<string>(localStorage.getItem("openai_api_key") || "");
   const [message, setMessage] = useState("");
+  const [htmlCode, setHtmlCode] = useState("");
+  const [cssjsCode, setCssjsCode] = useState("");
+  const [screenshot, setScreenshot] = useState<string | null>(null);
   const [nature, setNature] = useState<Nature | null>(null);
   const [response, setResponse] = useState("");
   const [codeBlocks, setCodeBlocks] = useState<CodeBlock[]>([]);
@@ -26,7 +30,23 @@ export default function App() {
     return raw ? JSON.parse(raw) : [];
   });
 
-  function buildPrompt(message: string, nature: Nature) {
+  const [dark, setDark] = useState<boolean>(
+    localStorage.getItem("theme") === "dark"
+  );
+
+  useEffect(() => {
+    document.body.classList.toggle("dark", dark);
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  }, [dark]);
+
+  function buildPrompt(
+    message: string,
+    nature: Nature,
+    html: string,
+    cssjs: string,
+  ) {
+    const htmlPart = html ? `\nCode HTML fourni :\n${html}` : "";
+    const cssPart = cssjs ? `\nCode CSS/JS fourni :\n${cssjs}` : "";
     if (nature === "Graphique") {
       return `Tu es chargé de support WiziShop. Génère une réponse professionnelle pour le partenaire, incluant la signature :
 - Réponds à la demande graphique de façon claire et courtoise, explique la solution.
@@ -37,7 +57,7 @@ Tristan
 *Chargé de site e-commerce*
 
 Message du partenaire :
-${message}`;
+${message}${htmlPart}${cssPart}`;
     } else {
       return `Tu es chargé de support WiziShop. Génère une réponse professionnelle complète à cette demande fonctionnelle (hors modification graphique) :
 - Réponds de façon claire, pédagogique, pro, et insère le bon lien de documentation WiziShop.
@@ -47,7 +67,7 @@ Tristan
 *Chargé de site e-commerce*
 
 Message du partenaire :
-${message}`;
+${message}${htmlPart}${cssPart}`;
     }
   }
 
@@ -56,24 +76,28 @@ ${message}`;
     setResponse("");
     setCodeBlocks([]);
     setLoading(true);
-    const n = analyzeNature(message);
+    const n = analyzeNature(message + htmlCode + cssjsCode);
     setNature(n);
 
     try {
       if (!apiKey) throw new Error("Aucune clé API OpenAI définie.");
       const openai = getOpenAI(apiKey);
 
+      const userContent: any[] = [
+        { type: "text", text: buildPrompt(message, n, htmlCode, cssjsCode) },
+      ];
+      if (screenshot) {
+        userContent.push({ type: "image_url", image_url: { url: screenshot } });
+      }
       const completion = await openai.chat.completions.create({
         model: "gpt-4o",
         messages: [
           {
             role: "system",
-            content: "Tu es un assistant support e-commerce expert WiziShop, très professionnel et synthétique.",
+            content:
+              "Tu es un assistant support e-commerce expert WiziShop, très professionnel et synthétique.",
           },
-          {
-            role: "user",
-            content: buildPrompt(message, n),
-          }
+          { role: "user", content: userContent },
         ],
         max_tokens: 500,
         temperature: 0.25,
@@ -110,13 +134,47 @@ ${message}`;
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
+  function resetFields() {
+    setMessage("");
+    setHtmlCode("");
+    setCssjsCode("");
+    setScreenshot(null);
+  }
+
+  function clearHistory() {
+    setHistory([]);
+    localStorage.removeItem("partnerreply_history");
+  }
+
   return (
-    <div className="min-h-screen bg-[#f8fafc] flex flex-col items-center p-4 sm:p-6">
+    <div
+      className={`min-h-screen flex flex-col items-center p-4 sm:p-6 ${dark ? 'bg-[#1a202c]' : 'bg-[#f8fafc]'}`}
+    >
       <h1 className="text-3xl font-bold mb-6 tracking-tight">PartnerReply</h1>
       <ApiKeyInput onChange={setApiKey} />
+      <OptionsBar
+        dark={dark}
+        toggleDark={() => setDark(d => !d)}
+        onReset={resetFields}
+        onClear={clearHistory}
+        loading={loading}
+      />
       <MessageInput
         value={message}
         onChange={setMessage}
+        html={htmlCode}
+        onChangeHtml={setHtmlCode}
+        cssjs={cssjsCode}
+        onChangeCssjs={setCssjsCode}
+        onFile={file => {
+          if (file) {
+            const reader = new FileReader();
+            reader.onloadend = () => setScreenshot(reader.result as string);
+            reader.readAsDataURL(file);
+          } else {
+            setScreenshot(null);
+          }
+        }}
         onGenerate={generateResponse}
         loading={loading}
       />
@@ -125,7 +183,7 @@ ${message}`;
         <div className="text-red-600 font-bold mt-2">{error}</div>
       )}
       {response && (
-        <div className="card">
+        <div className={`card${dark ? ' dark' : ''}`}>
           {/* Affiche la réponse texte sans les blocs code */}
           <div className="font-mono text-base whitespace-pre-line">
             {response.replace(/```([a-zA-Z]*)\n[\s\S]*?```/g, "[Bloc code séparé]")}
@@ -147,7 +205,7 @@ ${message}`;
         </div>
       )}
       {/* Historique */}
-      <HistoryPanel history={history} onRestore={restoreHistory} />
+      <HistoryPanel history={history} onRestore={restoreHistory} onClear={clearHistory} />
     </div>
   );
 }

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -15,13 +15,22 @@ export interface HistoryItem {
 export default function HistoryPanel({
   history,
   onRestore,
+  onClear,
 }: {
   history: HistoryItem[];
   onRestore: (item: HistoryItem) => void;
+  onClear: () => void;
 }) {
   return (
     <div className="w-full max-w-2xl mb-10">
-      <div className="font-bold text-lg mb-2 text-gray-700">Historique récent</div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="font-bold text-lg text-gray-700">Historique récent</div>
+        {history.length > 0 && (
+          <button onClick={onClear} className="text-xs border px-2 py-1 rounded">
+            Vider
+          </button>
+        )}
+      </div>
       {history.length === 0 && <div className="text-gray-400 text-sm">Aucune réponse enregistrée.</div>}
       <div className="flex flex-col gap-3">
         {history.map(item => (

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,11 +1,21 @@
 export default function MessageInput({
   value,
   onChange,
+  html,
+  onChangeHtml,
+  cssjs,
+  onChangeCssjs,
+  onFile,
   onGenerate,
   loading,
 }: {
   value: string;
   onChange: (v: string) => void;
+  html: string;
+  onChangeHtml: (v: string) => void;
+  cssjs: string;
+  onChangeCssjs: (v: string) => void;
+  onFile: (file: File | null) => void;
   onGenerate: () => void;
   loading: boolean;
 }) {
@@ -19,12 +29,38 @@ export default function MessageInput({
         className="border rounded-lg p-3 font-mono text-base"
         disabled={loading}
       />
+      <textarea
+        value={html}
+        onChange={e => onChangeHtml(e.target.value)}
+        placeholder="Code HTML (optionnel)"
+        rows={3}
+        className="border rounded-lg p-2 font-mono text-sm"
+        disabled={loading}
+      />
+      <textarea
+        value={cssjs}
+        onChange={e => onChangeCssjs(e.target.value)}
+        placeholder="Code CSS/JS (optionnel)"
+        rows={3}
+        className="border rounded-lg p-2 font-mono text-sm"
+        disabled={loading}
+      />
+      <input
+        type="file"
+        accept="image/*"
+        onChange={e => onFile(e.target.files ? e.target.files[0] : null)}
+        disabled={loading}
+      />
       <button
         onClick={onGenerate}
         disabled={!value || loading}
-        className="bg-black text-white px-6 py-2 rounded-lg font-bold hover:bg-gray-900 transition"
+        className="bg-black text-white px-6 py-2 rounded-lg font-bold hover:bg-gray-900 transition flex items-center justify-center"
       >
-        {loading ? "Génération en cours…" : "Analyser & Générer"}
+        {loading ? (
+          <span className="flex items-center gap-2"><span className="loader" />Génération…</span>
+        ) : (
+          "Analyser & Générer"
+        )}
       </button>
     </div>
   );

--- a/src/components/OptionsBar.tsx
+++ b/src/components/OptionsBar.tsx
@@ -1,0 +1,37 @@
+import { Moon, Sun, Trash2 } from "lucide-react";
+
+export default function OptionsBar({
+  dark,
+  toggleDark,
+  onReset,
+  onClear,
+  loading,
+}: {
+  dark: boolean;
+  toggleDark: () => void;
+  onReset: () => void;
+  onClear: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="flex gap-2 mb-4 items-center">
+      <button
+        onClick={toggleDark}
+        className="border px-2 py-1 rounded flex items-center gap-1"
+      >
+        {dark ? <Sun size={16} /> : <Moon size={16} />}
+        {dark ? "Light" : "Dark"} mode
+      </button>
+      <button
+        onClick={onReset}
+        disabled={loading}
+        className="border px-2 py-1 rounded"
+      >
+        Reset champ
+      </button>
+      <button onClick={onClear} className="border px-2 py-1 rounded flex items-center gap-1">
+        <Trash2 size={16} /> Effacer historique
+      </button>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,37 @@ a { color: #2980f1; text-decoration: none;}
 @media (max-width: 600px) {
   .card { padding: 1rem 0.5rem; }
 }
+
+.loader {
+  border: 3px solid #e2e8f0;
+  border-top-color: #2980f1;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+body.dark {
+  background: #1a202c;
+  color: #f4f7fb;
+}
+
+body.dark a { color: #63b3ed; }
+
+body.dark textarea,
+body.dark input {
+  background: #1f2937;
+  color: #f4f7fb;
+  border-color: #374151;
+}
+
+body.dark .card {
+  background: #171923;
+  color: #f4f7fb;
+  border-color: #22253b;
+}


### PR DESCRIPTION
## Summary
- add fields for HTML/CSS/JS codes and screenshot in the message form
- add dark mode toggle and reset/clear buttons
- implement OptionsBar component and loader animation
- include extra info in prompts
- support screenshot upload and dark mode styles
- update README with features list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687e813a34c48320b594ae00148c23f7