### PR TITLE
Revamp UI with galaxy theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>PartnerReply</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,41 +148,41 @@ ${message}${htmlPart}${cssPart}`;
   }
 
   return (
-    <div
-      className={`min-h-screen flex flex-col items-center p-4 sm:p-6 ${dark ? 'bg-[#1a202c]' : 'bg-[#f8fafc]'}`}
-    >
+    <div className="min-h-screen flex flex-col items-center p-4 sm:p-6 relative z-10">
       <h1 className="text-3xl font-bold mb-6 tracking-tight">PartnerReply</h1>
-      <ApiKeyInput onChange={setApiKey} />
-      <OptionsBar
-        dark={dark}
-        toggleDark={() => setDark(d => !d)}
-        onReset={resetFields}
-        onClear={clearHistory}
-        loading={loading}
-      />
-      <MessageInput
-        value={message}
-        onChange={setMessage}
-        html={htmlCode}
-        onChangeHtml={setHtmlCode}
-        cssjs={cssjsCode}
-        onChangeCssjs={setCssjsCode}
-        onFile={file => {
-          if (file) {
-            const reader = new FileReader();
-            reader.onloadend = () => setScreenshot(reader.result as string);
-            reader.readAsDataURL(file);
-          } else {
-            setScreenshot(null);
-          }
-        }}
-        onGenerate={generateResponse}
-        loading={loading}
-      />
-      {nature && <TagNature nature={nature} />}
-      {error && (
-        <div className="text-red-600 font-bold mt-2">{error}</div>
-      )}
+      <div className={`card${dark ? ' dark' : ''}`}>
+        <ApiKeyInput onChange={setApiKey} />
+        <OptionsBar
+          dark={dark}
+          toggleDark={() => setDark(d => !d)}
+          onReset={resetFields}
+          onClear={clearHistory}
+          loading={loading}
+        />
+        <MessageInput
+          value={message}
+          onChange={setMessage}
+          html={htmlCode}
+          onChangeHtml={setHtmlCode}
+          cssjs={cssjsCode}
+          onChangeCssjs={setCssjsCode}
+          onFile={file => {
+            if (file) {
+              const reader = new FileReader();
+              reader.onloadend = () => setScreenshot(reader.result as string);
+              reader.readAsDataURL(file);
+            } else {
+              setScreenshot(null);
+            }
+          }}
+          onGenerate={generateResponse}
+          loading={loading}
+        />
+        {nature && <TagNature nature={nature} />}
+        {error && (
+          <div className="text-red-500 font-bold mt-2">{error}</div>
+        )}
+      </div>
       {response && (
         <div className={`card${dark ? ' dark' : ''}`}>
           {/* Affiche la réponse texte sans les blocs code */}
@@ -195,7 +195,7 @@ ${message}${htmlPart}${cssPart}`;
           {/* Affiche les blocs code extraits */}
           {codeBlocks.length > 0 && (
             <div className="mt-4">
-              <div className="text-xs text-gray-500 font-semibold mb-1">
+              <div className="text-xs font-semibold mb-1" style={{ opacity: 0.7 }}>
                 Bloc{codeBlocks.length > 1 ? "s" : ""} code à copier :
               </div>
               {codeBlocks.map((block, idx) => (

--- a/src/components/ApiKeyInput.tsx
+++ b/src/components/ApiKeyInput.tsx
@@ -12,7 +12,7 @@ export default function ApiKeyInput({ onChange }: { onChange: (key: string) => v
     <div className="mb-4">
       <input
         type="password"
-        className="border px-2 py-1 rounded w-80"
+        className="w-80"
         placeholder="Clé API OpenAI"
         value={value}
         onChange={e => setValue(e.target.value)}
@@ -20,7 +20,7 @@ export default function ApiKeyInput({ onChange }: { onChange: (key: string) => v
       />
       <button
         onClick={handleSave}
-        className="ml-2 bg-gray-900 text-white px-3 py-1 rounded"
+        className="ml-2 primary"
         disabled={!value}
       >
         Sauver

--- a/src/components/CodeBlockCard.tsx
+++ b/src/components/CodeBlockCard.tsx
@@ -3,9 +3,9 @@ import type { CodeBlock } from "../utils/extractCodeBlocks";
 
 export default function CodeBlockCard({ block }: { block: CodeBlock }) {
   return (
-    <div className="my-4 bg-[#f3f4f6] border rounded-xl p-4 relative overflow-x-auto">
+    <div className="my-4 code-block">
       <div className="mb-2 flex items-center justify-between">
-        <span className="text-xs font-bold uppercase text-gray-600">
+        <span className="text-xs font-bold uppercase" style={{ opacity: 0.7 }}>
           {block.language || "code"}
         </span>
         <CopyButton value={block.code} />

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -13,10 +13,8 @@ export default function CopyButton({ value }: { value: string }) {
   return (
     <button
       onClick={handleCopy}
-      className={`ml-2 px-3 py-1 rounded transition border
-        ${copied ? "bg-green-100 border-green-400 text-green-800" : "bg-gray-100 border-gray-300 hover:bg-gray-200"}
-        flex items-center gap-2`}
-      style={{ fontWeight: 600 }}
+      className={`primary flex items-center gap-2 ${copied ? 'copied' : ''}`}
+      style={{ marginLeft: 8 }}
       title="Copier"
     >
       {copied ? <Check size={18} /> : <Copy size={18} />}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -26,12 +26,12 @@ export default function HistoryPanel({
       <div className="flex items-center justify-between mb-2">
         <div className="font-bold text-lg text-gray-700">Historique récent</div>
         {history.length > 0 && (
-          <button onClick={onClear} className="text-xs border px-2 py-1 rounded">
+          <button onClick={onClear} className="primary text-xs">
             Vider
           </button>
         )}
       </div>
-      {history.length === 0 && <div className="text-gray-400 text-sm">Aucune réponse enregistrée.</div>}
+      {history.length === 0 && <div className="text-sm" style={{ opacity: 0.7 }}>Aucune réponse enregistrée.</div>}
       <div className="flex flex-col gap-3">
         {history.map(item => (
           <div className="card" key={item.id} style={{ marginBottom: 8 }}>
@@ -42,16 +42,16 @@ export default function HistoryPanel({
               </span>
               <button
                 onClick={() => onRestore(item)}
-                className="px-2 py-1 rounded border bg-gray-100 text-xs hover:bg-gray-200 font-semibold"
+                className="primary text-xs"
               >
                 Réutiliser
               </button>
             </div>
-            <div className="text-xs mb-1 text-gray-500">Message partenaire :</div>
-            <div className="bg-gray-100 p-2 rounded text-xs mb-2">{item.message}</div>
+            <div className="text-xs mb-1" style={{ opacity: 0.7 }}>Message partenaire :</div>
+            <div className="history-message mb-2">{item.message}</div>
             <div className="flex gap-2">
               <CopyButton value={item.response} />
-              <span className="text-xs text-gray-400 pt-2">Copier la réponse</span>
+              <span className="text-xs pt-2" style={{ opacity: 0.7 }}>Copier la réponse</span>
             </div>
             {item.codeBlocks.length > 0 && (
               <div className="mt-3">

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -26,7 +26,7 @@ export default function MessageInput({
         onChange={e => onChange(e.target.value)}
         placeholder="Colle ici le message du partenaire…"
         rows={5}
-        className="border rounded-lg p-3 font-mono text-base"
+        className="font-mono text-base"
         disabled={loading}
       />
       <textarea
@@ -34,7 +34,7 @@ export default function MessageInput({
         onChange={e => onChangeHtml(e.target.value)}
         placeholder="Code HTML (optionnel)"
         rows={3}
-        className="border rounded-lg p-2 font-mono text-sm"
+        className="font-mono text-sm"
         disabled={loading}
       />
       <textarea
@@ -42,7 +42,7 @@ export default function MessageInput({
         onChange={e => onChangeCssjs(e.target.value)}
         placeholder="Code CSS/JS (optionnel)"
         rows={3}
-        className="border rounded-lg p-2 font-mono text-sm"
+        className="font-mono text-sm"
         disabled={loading}
       />
       <input
@@ -54,7 +54,7 @@ export default function MessageInput({
       <button
         onClick={onGenerate}
         disabled={!value || loading}
-        className="bg-black text-white px-6 py-2 rounded-lg font-bold hover:bg-gray-900 transition flex items-center justify-center"
+        className="primary flex items-center justify-center"
       >
         {loading ? (
           <span className="flex items-center gap-2"><span className="loader" />Génération…</span>

--- a/src/components/OptionsBar.tsx
+++ b/src/components/OptionsBar.tsx
@@ -17,7 +17,7 @@ export default function OptionsBar({
     <div className="flex gap-2 mb-4 items-center">
       <button
         onClick={toggleDark}
-        className="border px-2 py-1 rounded flex items-center gap-1"
+        className="secondary flex items-center gap-1"
       >
         {dark ? <Sun size={16} /> : <Moon size={16} />}
         {dark ? "Light" : "Dark"} mode
@@ -25,11 +25,11 @@ export default function OptionsBar({
       <button
         onClick={onReset}
         disabled={loading}
-        className="border px-2 py-1 rounded"
+        className="primary"
       >
         Reset champ
       </button>
-      <button onClick={onClear} className="border px-2 py-1 rounded flex items-center gap-1">
+      <button onClick={onClear} className="primary flex items-center gap-1">
         <Trash2 size={16} /> Effacer historique
       </button>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,26 +1,69 @@
 body {
   font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
-  background: #f8fafc;
   margin: 0;
+  color: #e5e7eb;
+  background: url('https://www.transparenttextures.com/patterns/stardust.png') repeat fixed, #0b1120;
+  position: relative;
+  min-height: 100vh;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 23, 39, 0.85);
+  z-index: -1;
+}
+
+body:not(.dark)::before {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+body:not(.dark) {
   color: #23272e;
 }
 * {
   box-sizing: border-box;
 }
-a { color: #2980f1; text-decoration: none;}
-::-webkit-scrollbar { height: 7px; }
+a { color: #63b3ed; text-decoration: none; }
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+}
+body:not(.dark) ::-webkit-scrollbar-thumb {
+  background: rgba(30, 41, 59, 0.4);
+}
 .card {
-  background: #fff;
+  background: rgba(255, 255, 255, 0.05);
   border-radius: 18px;
-  box-shadow: 0 3px 24px 0 rgba(30, 41, 59, 0.08);
-  border: 1px solid #e2e8f0;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   padding: 2rem 1.5rem;
   margin-bottom: 1.5rem;
   max-width: 38rem;
   width: 100%;
   position: relative;
+  backdrop-filter: blur(5px);
+  color: inherit;
 }
-.card.dark { background: #171923; color: #f4f7fb; border: 1px solid #22253b; }
+.card.dark {
+  background: rgba(23, 25, 35, 0.9);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #f4f7fb;
+}
+body:not(.dark) .card {
+  background: rgba(255, 255, 255, 0.85);
+  color: #23272e;
+  border-color: #e2e8f0;
+  box-shadow: 0 3px 24px rgba(30, 41, 59, 0.2);
+}
 .card .copy-btn { position: absolute; top: 18px; right: 18px;}
 @media (max-width: 600px) {
   .card { padding: 1rem 0.5rem; }
@@ -41,7 +84,6 @@ a { color: #2980f1; text-decoration: none;}
 }
 
 body.dark {
-  background: #1a202c;
   color: #f4f7fb;
 }
 
@@ -52,6 +94,82 @@ body.dark input {
   background: #1f2937;
   color: #f4f7fb;
   border-color: #374151;
+}
+
+input,
+textarea {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  color: inherit;
+}
+
+body:not(.dark) input,
+body:not(.dark) textarea {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: #cbd5e1;
+  color: #23272e;
+}
+
+button {
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.2s;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #3b82f6, #7c3aed);
+  color: #fff;
+  border: none;
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+.secondary:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+button.primary:hover {
+  filter: brightness(1.1);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.copied {
+  background: #16a34a !important;
+}
+
+.code-block {
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+body:not(.dark) .code-block {
+  background: #f3f4f6;
+  border-color: #e2e8f0;
+}
+
+.history-message {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+}
+
+body:not(.dark) .history-message {
+  background: #f3f4f6;
 }
 
 body.dark .card {


### PR DESCRIPTION
## Summary
- modernize font and title
- add galaxy background with overlay
- style cards, inputs, buttons, code blocks
- wrap form in central card
- tweak history panel UI
- remove local image and use remote star pattern

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e931ef9fc8320882403bdd2d9c9ae