### PR TITLE
Add embed mode for WordPress integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@ You can preview the built app locally using:
 ```bash
 npm run preview
 ```
+
+## Deploying to Vercel
+
+1. Create an account on [Vercel](https://vercel.com/) if you don't already have one.
+2. Push this repository to GitHub (or another Git provider).
+3. In Vercel, click **New Project** and import the repository.
+4. Keep the default settings. The build command is `npm run build` and the output directory is `dist`.
+5. Once the deployment finishes, note the public URL provided by Vercel.
+
+## Embedding in WordPress
+
+The application can be embedded in a page using an `<iframe>`.
+Add the query parameter `?embed=1` to enable the embed mode which removes the background.
+
+Example snippet to paste in your WordPress page:
+
+```html
+<iframe src="https://your-vercel-app.vercel.app/?embed=1"
+        style="width:100%;height:600px;border:0;" loading="lazy"></iframe>
+```

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      if (new URLSearchParams(window.location.search).get('embed') === '1') {
+        document.body.classList.add('embed');
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -177,3 +177,17 @@ body.dark .card {
   color: #f4f7fb;
   border-color: #22253b;
 }
+
+/* Embed mode for iframe integration */
+body.embed {
+  background: transparent;
+  min-height: auto;
+}
+
+body.embed::before {
+  display: none;
+}
+
+body.embed .card {
+  margin: 1rem auto;
+}


### PR DESCRIPTION
## Summary
- make index.html detect `?embed=1` and add `embed` class to the body
- style embed mode in `index.css`
- document Vercel deployment and WordPress iframe embed

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9c33c1948320ad61093c3011dfd7