### PR TITLE
Add env fallback for OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Features:
    npm run dev
    ```
 3. When the app is running, enter your OpenAI API key in the field at the top of the page. The key is stored locally in `localStorage` under `openai_api_key`.
+   If no key is found in `localStorage`, the application will also look for
+   an environment variable named `VITE_OPENAI_API_KEY` provided at build time
+   (for example in a `.env` file). This allows deployments to supply the key
+   automatically without user input.
 
 ## Building for production
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,8 +81,9 @@ ${message}${htmlPart}${cssPart}`;
     setNature(n);
 
     try {
-      if (!apiKey) throw new Error("Aucune clé API OpenAI définie.");
-      const openai = getOpenAI(apiKey);
+      const finalApiKey = apiKey || import.meta.env.VITE_OPENAI_API_KEY || "";
+      if (!finalApiKey) throw new Error("Aucune clé API OpenAI définie.");
+      const openai = getOpenAI(finalApiKey);
 
       const userContent: ChatCompletionContentPart[] = [
         { type: "text", text: buildPrompt(message, n, htmlCode, cssjsCode) },

--- a/src/utils/openaiClient.ts
+++ b/src/utils/openaiClient.ts
@@ -1,8 +1,9 @@
 import { OpenAI } from "openai";
 
-export function getOpenAI(apiKey: string) {
+export function getOpenAI(apiKey?: string) {
+  const key = apiKey || import.meta.env.VITE_OPENAI_API_KEY;
   return new OpenAI({
-    apiKey,
+    apiKey: key,
     dangerouslyAllowBrowser: true, // obligatoire côté frontend
   });
 }


### PR DESCRIPTION
## Summary
- allow `getOpenAI` to pull the API key from `import.meta.env.VITE_OPENAI_API_KEY`
- fall back to this env variable in `App.tsx`
- document the environment variable option in the README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb769d5dc8320878a3deae4527c20