### PR TITLE
Add Wizishop doc links helper

### DIFF
--- a/public/docs.json
+++ b/public/docs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Créer un produit",
+    "url": "https://help.wizishop.fr/fr/articles/creer-un-produit"
+  },
+  {
+    "title": "Configurer les modes de livraison",
+    "url": "https://help.wizishop.fr/fr/articles/configurer-les-modes-de-livraison"
+  },
+  {
+    "title": "Gérer les promotions",
+    "url": "https://help.wizishop.fr/fr/articles/gerer-les-promotions"
+  }
+]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ApiKeyInput from "./components/ApiKeyInput";
 import CopyButton from "./components/CopyButton";
 import CodeBlockCard from "./components/CodeBlockCard";
 import HistoryPanel from "./components/HistoryPanel";
+import DocLinks from "./components/DocLinks";
 import OptionsBar from "./components/OptionsBar";
 import { analyzeNature } from "./utils/analyzeNature";
 import { extractCodeBlocks } from "./utils/extractCodeBlocks";
@@ -206,6 +207,7 @@ ${message}${htmlPart}${cssPart}`;
           )}
         </div>
       )}
+      <DocLinks />
       {/* Historique */}
       <HistoryPanel history={history} onRestore={restoreHistory} onClear={clearHistory} />
     </div>

--- a/src/components/DocLinks.tsx
+++ b/src/components/DocLinks.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+
+interface DocLink {
+  title: string;
+  url: string;
+}
+
+export default function DocLinks() {
+  const [docs, setDocs] = useState<DocLink[]>([]);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    fetch("/docs.json")
+      .then(res => res.json())
+      .then((data: DocLink[]) => setDocs(data))
+      .catch(() => setDocs([]));
+  }, []);
+
+  const filtered = query
+    ? docs.filter(d => d.title.toLowerCase().includes(query.toLowerCase()))
+    : docs;
+
+  return (
+    <div className="doc-links card">
+      <h2 className="text-lg font-semibold mb-2">Liens documentation WiziShop</h2>
+      <input
+        type="text"
+        placeholder="Rechercher..."
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        className="mb-2 w-full"
+      />
+      <ul className="list-disc pl-5 space-y-1">
+        {filtered.map(doc => (
+          <li key={doc.url}>
+            <a
+              href={doc.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => {
+                e.preventDefault();
+                navigator.clipboard.writeText(doc.url).catch(() => {});
+              }}
+            >
+              {doc.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+      <p className="text-xs mt-2 opacity-70">
+        Cliquer sur un titre copie l\'URL dans le presse-papiers.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add sample WiziShop documentation links (docs.json)
- provide `DocLinks` component to search and copy URLs
- display doc links section in the app

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68869799d0c88320b39b72006ee9bf23