### PR TITLE
Enhance doc link management

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ Example snippet to paste in your WordPress page:
 <iframe src="https://your-vercel-app.vercel.app/?embed=1"
         style="width:100%;height:600px;border:0;" loading="lazy"></iframe>
 ```
+
+## Managing WiziShop documentation links
+
+The side panel "Liens documentation WiziShop" lists useful articles. You can
+search the list, click a title to copy its URL, and add your own links.
+
+1. Fill in a title and URL below the list then click **Ajouter**. Custom links
+   are stored locally in `localStorage` under `custom_doc_links`.
+2. Use the **×** button next to a custom link to remove it.
+3. Click **Réinitialiser liens perso** to clear all custom links.
+
+Default links are defined in `public/docs.json` and can be edited to update the
+initial list.

--- a/src/components/DocLinks.tsx
+++ b/src/components/DocLinks.tsx
@@ -7,18 +7,54 @@ interface DocLink {
 
 export default function DocLinks() {
   const [docs, setDocs] = useState<DocLink[]>([]);
+  const [customDocs, setCustomDocs] = useState<DocLink[]>([]);
   const [query, setQuery] = useState("");
+  const [newTitle, setNewTitle] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+
+  const CUSTOM_KEY = "custom_doc_links";
 
   useEffect(() => {
     fetch("/docs.json")
       .then(res => res.json())
       .then((data: DocLink[]) => setDocs(data))
       .catch(() => setDocs([]));
+    const stored = localStorage.getItem(CUSTOM_KEY);
+    if (stored) {
+      try {
+        setCustomDocs(JSON.parse(stored));
+      } catch {
+        setCustomDocs([]);
+      }
+    }
   }, []);
 
+  function saveCustom(newDocs: DocLink[]) {
+    setCustomDocs(newDocs);
+    localStorage.setItem(CUSTOM_KEY, JSON.stringify(newDocs));
+  }
+
+  function handleAdd() {
+    if (!newTitle.trim() || !newUrl.trim()) return;
+    const updated = [...customDocs, { title: newTitle.trim(), url: newUrl.trim() }];
+    saveCustom(updated);
+    setNewTitle("");
+    setNewUrl("");
+  }
+
+  function handleRemove(url: string) {
+    const updated = customDocs.filter(d => d.url !== url);
+    saveCustom(updated);
+  }
+
+  function handleClear() {
+    saveCustom([]);
+  }
+
+  const allDocs = [...docs, ...customDocs];
   const filtered = query
-    ? docs.filter(d => d.title.toLowerCase().includes(query.toLowerCase()))
-    : docs;
+    ? allDocs.filter(d => d.title.toLowerCase().includes(query.toLowerCase()))
+    : allDocs;
 
   return (
     <div className="doc-links card">
@@ -30,9 +66,9 @@ export default function DocLinks() {
         onChange={e => setQuery(e.target.value)}
         className="mb-2 w-full"
       />
-      <ul className="list-disc pl-5 space-y-1">
+      <ul className="list-disc pl-5 space-y-1 mb-2">
         {filtered.map(doc => (
-          <li key={doc.url}>
+          <li key={doc.url} className="flex items-center gap-2">
             <a
               href={doc.url}
               target="_blank"
@@ -41,14 +77,48 @@ export default function DocLinks() {
                 e.preventDefault();
                 navigator.clipboard.writeText(doc.url).catch(() => {});
               }}
+              className="flex-grow"
             >
               {doc.title}
             </a>
+            {customDocs.some(c => c.url === doc.url) && (
+              <button
+                onClick={() => handleRemove(doc.url)}
+                className="secondary text-xs"
+                title="Supprimer"
+              >
+                ×
+              </button>
+            )}
           </li>
         ))}
       </ul>
+      <div className="flex gap-2 mb-2">
+        <input
+          type="text"
+          placeholder="Titre..."
+          value={newTitle}
+          onChange={e => setNewTitle(e.target.value)}
+          className="flex-grow"
+        />
+        <input
+          type="text"
+          placeholder="URL..."
+          value={newUrl}
+          onChange={e => setNewUrl(e.target.value)}
+          className="flex-grow"
+        />
+        <button onClick={handleAdd} className="primary text-xs">
+          Ajouter
+        </button>
+      </div>
+      {customDocs.length > 0 && (
+        <button onClick={handleClear} className="primary text-xs mb-2">
+          Réinitialiser liens perso
+        </button>
+      )}
       <p className="text-xs mt-2 opacity-70">
-        Cliquer sur un titre copie l\'URL dans le presse-papiers.
+        Cliquer sur un titre copie l'URL dans le presse-papiers.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- expand doc link management in the UI
- explain how to customize doc links in README

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68869d35728c8320835e6c17467bb9a5