### PR TITLE
Enable removing default docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ search the list, click a title to copy its URL, and add your own links.
    are stored locally in `localStorage` under `custom_doc_links`.
 2. Use the **×** button next to a custom link to remove it.
 3. Click **Réinitialiser liens perso** to clear all custom links.
+4. Default links can also be removed using the **×** button and restored with
+   **Réinitialiser liens par défaut**.
 
 Default links are defined in `public/docs.json` and can be edited to update the
 initial list.


### PR DESCRIPTION
## Summary
- allow deleting default documentation links and restoring defaults
- document this feature

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68869e60364083208114320c3d8c44ba