### PR TITLE
Fix docs fetch path for custom Vite base

### DIFF
--- a/src/components/DocLinks.tsx
+++ b/src/components/DocLinks.tsx
@@ -17,7 +17,7 @@ export default function DocLinks() {
   const REMOVE_KEY = "removed_doc_links";
 
   useEffect(() => {
-    fetch("/docs.json")
+    fetch(new URL("../public/docs.json", import.meta.url))
       .then(res => res.json())
       .then((data: DocLink[]) => setDocs(data))
       .catch(() => setDocs([]));


### PR DESCRIPTION
## Summary
- load docs.json via module-relative URL to support custom base paths
- verify docs.json loads when served with a different `base` in Vite

## Testing
- `npm run lint`
- `npm test`
- `npm run build -- --base=/sub/`
- `curl -s http://localhost:4174/sub/docs.json | head -n 2`

------
https://chatgpt.com/codex/tasks/task_e_6887879b1cd48320b24e92ecd544a56c